### PR TITLE
socket moved as private member of Client

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,8 +25,12 @@ class Client {
     this.#client.destroy();
   }
 
-  submit(worker, job_id, extranonce2, ntime, nonce) {
-    submitWork(worker, job_id, extranonce2, ntime, nonce, this.#client);
+  submit(options) {
+    const client = this.#client;
+    submitWork({
+      ...options,
+      client,
+    });
   }
 
   #start(options) {

--- a/src/submitWork.js
+++ b/src/submitWork.js
@@ -2,6 +2,6 @@ const {
   submitWork
 } = require('./messageContants');
 
-module.exports = (worker, job_id, extranonce2, ntime, nonce, client) => {
-  client.write(submitWork.replace("<worker.name>", worker).replace("<jobID>", job_id).replace("<ExtraNonce2>", extranonce2).replace("<ntime>", ntime).replace("<nonce>", nonce));
+module.exports = options => {
+  options.client.write(submitWork.replace("<worker.name>", options.worker_name).replace("<jobID>", options.job_id).replace("<ExtraNonce2>", options.extranonce2).replace("<ntime>", options.ntime).replace("<nonce>", options.nonce));
 };

--- a/src/submitWork.js
+++ b/src/submitWork.js
@@ -2,6 +2,6 @@ const {
   submitWork
 } = require('./messageContants');
 
-module.exports = (options) => {
-  options.client.write(submitWork.replace("<worker.name>", options.worker_name).replace("<jobID>", options.job_id).replace("<ExtraNonce2>", options.extranonce2).replace("<ntime>", options.ntime).replace("<nonce>", options.nonce));
+module.exports = (worker, job_id, extranonce2, ntime, nonce, client) => {
+  client.write(submitWork.replace("<worker.name>", worker).replace("<jobID>", job_id).replace("<ExtraNonce2>", extranonce2).replace("<ntime>", ntime).replace("<nonce>", nonce));
 };


### PR DESCRIPTION
Using one global socket does not allow multiple clients to connect. This fix allows instantiation and connection of two or more clients at the same time.